### PR TITLE
"Backlog" functionality ghosting articles after PRAW restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-install:
 
 .PHONY: test-unit
 test-unit:
-	cask exec ert-runner -L . -L test tests/test*.el
+	cask exec ert-runner -L . -L tests tests/test*.el
 
 .PHONY: test
 test: test-compile test-unit test-int

--- a/tests/test-uncacheable.el
+++ b/tests/test-uncacheable.el
@@ -1,0 +1,5 @@
+(require 'test)
+
+(ert-deftest nnreddit-should-not-cache ()
+  (should (string-match gnus-uncacheable-groups "nnreddit:emacs")))
+

--- a/tests/test.el
+++ b/tests/test.el
@@ -4,6 +4,7 @@
 
 (require 'nnreddit)
 (require 'cl-lib)
+(require 'ert)
 
 (defun test-wait-for (predicate &optional predargs ms interval continue)
   "Wait until PREDICATE function returns non-`nil'.


### PR DESCRIPTION
Clear the "backlog" when PRAW dies.  And don't cache, generally.