### PR TITLE
melpa feedback part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ before_script:
 
 script:
   - make test-install
-  - make test || ( ( printf "To diagnose, travis logs -i | dos2unix | sed '/^begin 664/,/^end/!d' | uudecode" ) && ( zip -q - tests/log/* 2>/dev/null | uuencode log.zip ) && false)
+  - make test || ( ( printf "To diagnose, travis logs -i | dos2unix | sed '/^begin 644/,/^end/!d' | uudecode\n" ) && ( zip -q - tests/log/* 2>/dev/null | uuencode log.zip ) && false)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 .PHONY: test-compile
 test-compile: autoloads
 	cask install
-	! (cask eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | grep -a "Error:")
+	! (cask eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):")
 	cask clean-elc
 
 .PHONY: test-install


### PR DESCRIPTION
Address various automated warnings.
Did not address variables starting with asterisk.
Did not address checkdoc warnings