### PR TITLE
melpa linting part 2

### DIFF
--- a/tools/package-lint.sh
+++ b/tools/package-lint.sh
@@ -30,9 +30,10 @@ fi
 # Lint failures are ignored if EMACS_LINT_IGNORE is defined, so that lint
 # failures on Emacs 24.2 and below don't cause the tests to fail, as these
 # versions have buggy imenu that reports (defvar foo) as a definition of foo.
+# Reduce purity via:
+# --eval "(fset 'package-lint--check-defs-prefix (symbol-function 'ignore))" \
 "$EMACS" -Q -batch \
          --eval "$INIT_PACKAGE_EL" \
          -l package-lint.el \
-         --eval "(fset 'package-lint--check-defs-prefix (symbol-function 'ignore))" \
          -f package-lint-batch-and-exit \
          lisp/nnreddit.el || [ -n "${EMACS_LINT_IGNORE+x}" ]


### PR DESCRIPTION
https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html
"In some other systems there is a convention of choosing variable names that begin and end with ‘*’. We don't use that convention in Emacs Lisp, so please don't use it in your programs."