### PR TITLE
Patch setup holes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-super-secret-refresh-token
 .ecukes*
 .cask
 .newsrc*

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,7 @@ install:
       eval "$(pyenv init -)"
       pyenv activate $TOXENV
     fi
-  - pip install virtualenvwrapper
   - pip install pylint
-  - |
-    if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
-      source $HOME/.pyenv/versions/2.7.*/envs/py27/bin/virtualenvwrapper.sh
-    else
-      source virtualenvwrapper.sh
-    fi
   - pip install -r requirements-dev.txt
 
 before_script:
@@ -65,5 +58,5 @@ before_script:
   - sh tools/install-cask.sh
 
 script:
-  - make test-install
+  - make test-venv
   - make test || ( ( printf "To diagnose, travis logs -i | dos2unix | sed '/^begin 644/,/^end/!d' | uudecode\n" ) && ( zip -q - tests/log/* 2>/dev/null | uuencode log.zip ) && false)

--- a/Cask
+++ b/Cask
@@ -1,7 +1,7 @@
 (source melpa)
 
 (package-descriptor "lisp/nnreddit-pkg.el")
-(files "lisp/*.el" "setup.py" "nnreddit")
+(files "lisp/*.el" "setup.py" "requirements.txt" "nnreddit")
 
 (development
  (depends-on "ert-runner")

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,14 @@ test-install:
 	           (oset rcp :branch my-branch) \
 	           (oset rcp :commit my-commit))" \
 	--eval "(package-build--package rcp (package-build--checkout rcp))" \
-	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"nnreddit*.tar\"))))" 2>&1 | egrep -a "Error: " )
+	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"nnreddit*.tar\"))))" 2>&1 | egrep -ia "error: |fatal" )
+
+.PHONY: test-venv
+test-venv: test-install
+	emacs -Q --batch --eval "(package-initialize)" \
+	                 --eval "(custom-set-variables (quote (gnus-verbose 8)))" \
+	                 --eval "(require (quote nnreddit))" \
+	                 --eval "nnreddit-venv"
 
 .PHONY: test-unit
 test-unit:

--- a/features/rpc.feature
+++ b/features/rpc.feature
@@ -119,3 +119,15 @@ Scenario: supersede post
   And I wait for buffer to say "api/editusertext"
   And I wait for buffer to say "('thing_id', 't1_eqwe7dx')"
   Then end recording "supersede"
+
+@browser
+Scenario: Verify user message if no refresh token present
+  Given gnus stop
+  And I hide tokens
+  And gnus try start
+  And I switch to buffer "*Messages*"
+  Then I should see "nnreddit-default: Please check your browser."
+  And I unhide tokens
+  And I kill all rpc processes
+
+

--- a/features/step-definitions/nnreddit-steps.el
+++ b/features/step-definitions/nnreddit-steps.el
@@ -1,3 +1,15 @@
+(When "I kill all rpc processes$"
+      (lambda ()
+        (nnreddit-request-close)))
+
+(When "I hide tokens$"
+      (lambda ()
+        (setq nnreddit--python-module-extra-args '("--token-file" "/dev/null"))))
+
+(When "I unhide tokens$"
+      (lambda ()
+        (setq nnreddit--python-module-extra-args nil)))
+
 (When "^rpc \"\\(.*\\)\" returns \"\\(.*\\)\"$"
       (lambda (command result)
         (should (string= result (nnreddit-rpc-call nil nil command)))))
@@ -31,12 +43,13 @@
 (When "^I dump buffer"
       (lambda () (message "%s" (buffer-string))))
 
-(When "^gnus start$"
-      (lambda ()
+(When "^gnus \\(try \\)?start\\(\\)$"
+      (lambda (demote _workaround)
         (nnreddit-aif (get-buffer gnus-group-buffer)
             (switch-to-buffer it)
-          (When "I call \"gnus\"")
-          (Then "I should be in buffer \"%s\"" gnus-group-buffer))))
+          (if-demote demote
+            (When "I call \"gnus\"")
+            (Then "I should be in buffer \"%s\"" gnus-group-buffer)))))
 
 (When "^gnus stop$"
       (lambda ()

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -3,31 +3,19 @@
 (require 'espuds)
 (require 'f)
 
-(with-eval-after-load "python"
-  (setq python-indent-guess-indent-offset-verbose nil))
-
 (let* ((support-path (f-dirname load-file-name))
        (root-path (f-parent (f-parent support-path))))
   (add-to-list 'load-path (concat root-path "/lisp"))
-  (add-to-list 'load-path (concat root-path "/tests"))
-  (custom-set-variables
-   '(gnus-before-startup-hook (quote (toggle-debug-on-error)))
-   '(nnreddit-use-virtualenv nil)
-   '(auto-revert-verbose nil)
-   '(auto-revert-stop-on-user-input nil)
-   '(gnus-read-active-file nil)
-   `(gnus-home-directory ,(concat root-path "/tests"))
-   '(gnus-use-dribble-file nil)
-   '(gnus-read-newsrc-file nil)
-   '(gnus-save-killed-list nil)
-   '(gnus-save-newsrc-file nil)
-   '(gnus-secondary-select-methods (quote ((nnreddit ""))))
-   '(gnus-select-method (quote (nnnil)))
-   '(gnus-message-highlight-citation nil)
-   '(gnus-verbose 8)
-   '(gnus-interactive-exit (quote quiet))))
+  (add-to-list 'load-path (concat root-path "/tests")))
 
 (require 'nnreddit-test)
+
+(defmacro if-demote (demote &rest forms)
+  (declare (debug t) (indent 1))
+  `(if ,demote
+       (with-demoted-errors "demoted: %s"
+         ,@forms)
+     ,@forms))
 
 (defun cleanup ()
   (let* ((newsrc-file gnus-current-startup-file)
@@ -48,7 +36,7 @@
 
 (Fail
  (if noninteractive
-     (progn
+     (with-demoted-errors "demote: %s"
        (Then "end recordings")
        (Teardown))
    (backtrace)

--- a/lisp/nnreddit.el
+++ b/lisp/nnreddit.el
@@ -70,24 +70,49 @@
   :group 'nnreddit)
 
 (defcustom nnreddit-venv
-  (unless noninteractive
-    (let* ((library-directory (file-name-directory (locate-library "nnreddit")))
-           (defacto-version (file-name-nondirectory
-                             (directory-file-name library-directory)))
-           (result (concat defacto-version "-" nnreddit-python-command)))
-      (prog1 result
-        (gnus-message 7 "nnreddit-venv: %s%s" venv-location result)
-        (unless (member result (split-string (venv-list-virtualenvs)))
-          (gnus-message 5 "nnreddit-venv: installing venv to %s..." result)
-          (condition-case err
-              (progn
-                (venv-mkvirtualenv-using nnreddit-python-command result)
-                (venv-with-virtualenv-shell-command
-                 result
-                 (format "cd %s && python setup.py install" library-directory)))
-            (error (venv-rmvirtualenv result)
-                   (error (error-message-string err))))
-          (gnus-message 5 "nnreddit-venv: installing venv to %s...done" result)))))
+  (let* ((library-directory (file-name-directory (locate-library "nnreddit")))
+         (defacto-version (file-name-nondirectory
+                           (directory-file-name library-directory)))
+         (result (concat defacto-version "-" nnreddit-python-command))
+         (requirements (concat library-directory "requirements.txt"))
+         (install-args (if (file-exists-p requirements)
+                           (list "-r" requirements)
+                         (list "virtualenv")))
+         (already-in-venv
+          (not (zerop (apply #'call-process nnreddit-python-command
+                             nil nil nil
+                             (list
+                              "-c"
+                              "import sys; sys.exit(hasattr(sys, 'real_prefix'))")))))
+         (pip-args (append (list "-m" "pip" "install")
+                           (unless already-in-venv (list "--user"))
+                           install-args))
+         (pip-status
+          (apply #'call-process nnreddit-python-command nil nil nil
+                 pip-args)))
+    (gnus-message 7 "nnreddit-venv: %s %s" nnreddit-python-command
+                  (mapconcat 'identity pip-args " "))
+    (cond ((numberp pip-status)
+           (unless (zerop pip-status)
+             (gnus-message 3 "nnreddit-venv: pip install exit %s" pip-status)))
+          (t (gnus-message 3 "nnreddit-venv: pip install signal %s" pip-status)))
+    (prog1 result
+      (gnus-message 7 "nnreddit-venv: %s%s" venv-location result)
+      (unless (file-exists-p venv-location)
+        (make-directory venv-location))
+      (unless (member result (split-string (venv-list-virtualenvs)))
+        (gnus-message 5 "nnreddit-venv: installing venv to %s..." result)
+        (condition-case err
+            (progn
+              (venv-mkvirtualenv-using nnreddit-python-command result)
+              (venv-with-virtualenv-shell-command
+               result
+               ;; `python` and not `nnreddit-python-command` because
+               ;; venv normalizes the executable to `python`.
+               (format "cd %s && python setup.py install" library-directory)))
+          (error (venv-rmvirtualenv result)
+                 (error (error-message-string err))))
+        (gnus-message 5 "nnreddit-venv: installing venv to %s...done" result))))
   "Venv directory name in `venv-location'.
 
 To facilitate upgrades, the name gloms a de facto version (the directory
@@ -113,7 +138,21 @@ name where this file resides) and the `nnreddit-python-command'."
   :type 'boolean
   :group 'nnreddit)
 
+(defcustom nnreddit-rpc-request-timeout 60
+  "Turn on PRAW logging."
+  :type 'integer
+  :group 'nnreddit)
+
+(defcustom nnreddit-localhost "127.0.0.1"
+  "Some users keep their browser in a separate domain.
+
+Do not set this to \"localhost\" as a numeric IP is required for the oauth handshake."
+  :type 'string
+  :group 'nnreddit)
+
 (defvar nnreddit-rpc-log-filename nil)
+
+(defvar nnreddit--python-module-extra-args nil "Primarily for testing.")
 
 (define-minor-mode nnreddit-article-mode
   "Minor mode for nnreddit articles.  Disallow `gnus-article-reply-with-original'.
@@ -275,7 +314,7 @@ Normalize it to \"nnreddit-default\"."
 Process stays the same, but the jsonrpc connection (a cheap struct) gets reinstantiated with every call."
   (nnreddit--normalize-server)
   (let* ((connection (json-rpc--create :process (nnreddit-rpc-get server)
-                                       :host "localhost"
+                                       :host nnreddit-localhost
                                        :id-counter 0))
          (result (apply #'nnreddit-rpc-request connection generator_kwargs method args)))
     result))
@@ -679,6 +718,13 @@ and LVP (list of vectors of plists).  Used in the interleaving of submissions an
     (setq nnreddit-headers-hashtb (gnus-make-hashtable))
     (gnus-backlog-shutdown)))
 
+(defun nnreddit--message-user (server beg end _prev-len)
+  "Message SERVER related alert with `buffer-substring' from BEG to END."
+  (let ((string (buffer-substring beg end))
+        (magic "::user::"))
+    (when (string-prefix-p magic string)
+      (message "%s: %s" server (substring string (length magic))))))
+
 (defun nnreddit-rpc-get (&optional server)
   "Retrieve the PRAW process for SERVER."
   (nnreddit--normalize-server)
@@ -695,18 +741,27 @@ and LVP (list of vectors of plists).  Used in the interleaving of submissions an
                                     (format "%s%s/bin/python" venv-location nnreddit-venv)
                                   (executable-find nnreddit-python-command)))
              (python-module (if (featurep 'nnreddit-test) "tests" "nnreddit"))
-             (praw-command (list python-executable "-m" python-module)))
-        (when nnreddit-log-rpc
-          (setq nnreddit-rpc-log-filename
-                (concat (file-name-as-directory temporary-file-directory) "nnreddit-rpc-log."))
-          (setq praw-command (append praw-command (list "--log" nnreddit-rpc-log-filename))))
+             (praw-command (append (list python-executable "-m" python-module)
+                                   nnreddit--python-module-extra-args)))
+        (unless (featurep 'nnreddit-test)
+          (setq praw-command (append praw-command (list "--localhost" nnreddit-localhost)))
+          (when nnreddit-log-rpc
+            (setq nnreddit-rpc-log-filename
+                  (concat (file-name-as-directory temporary-file-directory)
+                          "nnreddit-rpc-log."))
+            (setq praw-command (append praw-command
+                                       (list "--log" nnreddit-rpc-log-filename)))))
         (setq proc (make-process :name server
                                  :buffer (get-buffer-create (format " *%s*" server))
                                  :command praw-command
                                  :connection-type 'pipe
                                  :noquery t
                                  :sentinel #'nnreddit-sentinel
-                                 :stderr (get-buffer-create (format " *%s-stderr*" server)))))
+                                 :stderr (get-buffer-create (format " *%s-stderr*" server))))
+        (with-current-buffer (get-buffer-create (format " *%s-stderr*" server))
+          (add-hook 'after-change-functions
+                    (apply-partially 'nnreddit--message-user server)
+                    nil t)))
       (push proc nnreddit-processes))
     proc))
 
@@ -721,12 +776,13 @@ and LVP (list of vectors of plists).  Used in the interleaving of submissions an
          (proc (json-rpc-process (json-rpc-ensure connection)))
          (encoded (json-encode (append '(:jsonrpc "2.0") request)))
          (json-object-type 'plist)
-         (json-key-type 'keyword))
+         (json-key-type 'keyword)
+         (iteration-seconds 6))
     (with-current-buffer (process-buffer proc)
       (erase-buffer)
       (gnus-message 7 "nnreddit-rpc-request: send %s" encoded)
       (process-send-string proc (concat encoded "\n"))
-      (cl-loop repeat 10
+      (cl-loop repeat (/ nnreddit-rpc-request-timeout iteration-seconds)
                with result
                until (or (not (json-rpc-live-p connection))
                          (and (not (zerop (length (buffer-string))))
@@ -743,7 +799,7 @@ and LVP (list of vectors of plists).  Used in the interleaving of submissions an
                                                            (error-message-string err)
                                                            resp))))
                                  nil))))
-               do (accept-process-output proc 6 0)
+               do (accept-process-output proc iteration-seconds 0)
                finally return
                (cond ((null result)
                       (error "nnreddit-rpc-request: response timed out"))

--- a/lisp/nnreddit.el
+++ b/lisp/nnreddit.el
@@ -128,9 +128,7 @@ name where this file resides) and the `nnreddit-python-command'."
       "0" nnreddit-novote
       "-" nnreddit-downvote
       "=" nnreddit-upvote
-      "+" nnreddit-upvote)
-    ;; WHY????
-    (define-key gnus-article-mode-map "F" 'gnus-summary-followup-with-original)))
+      "+" nnreddit-upvote)))
 
 (define-minor-mode nnreddit-summary-mode
   "Disallow \"reply\" commands in `gnus-summary-mode-map'.

--- a/nnreddit/__main__.py
+++ b/nnreddit/__main__.py
@@ -14,6 +14,7 @@ from .authenticated_reddit import AuthenticatedReddit
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--log", help="log filename")
+parser.add_argument("--localhost", help="ip or hostname of localhost", default='127.0.0.1')
 args = parser.parse_args()
 
 stdin = sys.stdin
@@ -22,5 +23,6 @@ if __name__ != "__main__":
     sys.stdout = sys.stderr = open(os.devnull, "w")
 
 jsonrpyc.RPC(target=AuthenticatedReddit(check_for_updates=False,
-                                        log_prefix=args.log),
+                                        log_prefix=args.log,
+                                        localhost=args.localhost),
              stdin=stdin, stdout=stdout)

--- a/nnreddit/templates/index.html
+++ b/nnreddit/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>RTV OAuth2 Helper</title>
+    <title>Nnreddit OAuth2 Helper</title>
     <!-- style borrowed from http://bettermotherfuckingwebsite.com/ -->
     <style type="text/css">
     body {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+virtualenv

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -8,7 +8,12 @@ python -m nnreddit
 import os
 import sys
 import jsonrpyc
+import argparse
 from tempfile import mkstemp
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--token-file", help="refresh token filename")
+args = parser.parse_args()
 
 os.environ["XDG_DATA_HOME"] = os.path.join(os.path.dirname(__file__), 'share')
 try:
@@ -33,7 +38,7 @@ except OSError:
         raise
 
 super_secret = os.path.join(os.path.dirname(TOKEN), 'super-secret-refresh-token')
-kwargs = { 'token_file': (super_secret if os.path.exists(super_secret) else TOKEN),
+kwargs = { 'token_file': args.token_file if args.token_file else (super_secret if os.path.exists(super_secret) else TOKEN),
            'history_file': mkstemp(dir='/var/tmp')[1],
 }
 jsonrpyc.RPC(target=AuthenticatedReddit(log_prefix=os.path.join(logdir, 'test_py.'),

--- a/tests/nnreddit-test.el
+++ b/tests/nnreddit-test.el
@@ -4,10 +4,30 @@
 ;; https://github.com/millejoh/emacs-ipython-notebook
 ;; licensed under GNU General Public License v3.0.
 
+(custom-set-variables
+ '(gnus-before-startup-hook (quote (toggle-debug-on-error)))
+ '(nnreddit-venv nil)
+ '(auto-revert-verbose nil)
+ '(auto-revert-stop-on-user-input nil)
+ '(gnus-read-active-file nil)
+ `(gnus-home-directory ,(file-name-directory load-file-name))
+ '(gnus-use-dribble-file nil)
+ '(gnus-read-newsrc-file nil)
+ '(gnus-save-killed-list nil)
+ '(gnus-save-newsrc-file nil)
+ '(gnus-secondary-select-methods (quote ((nnreddit ""))))
+ '(gnus-select-method (quote (nnnil)))
+ '(gnus-message-highlight-citation nil)
+ '(gnus-verbose 8)
+ '(gnus-interactive-exit (quote quiet)))
+
 (require 'nnreddit)
 (require 'cl-lib)
 (require 'ert)
 (require 'message)
+
+(with-eval-after-load "python"
+  (setq python-indent-guess-indent-offset-verbose nil))
 
 (defun nnreddit-test-wait-for (predicate &optional predargs ms interval continue)
   "Wait until PREDICATE function returns non-`nil'.

--- a/tools/recipe
+++ b/tools/recipe
@@ -1,2 +1,2 @@
 (nnreddit :repo "dickmao/nnreddit" :fetcher github
-          :files ("lisp/*.el" "setup.py" "nnreddit"))
+          :files ("lisp/*.el" "setup.py" "requirements.txt" "nnreddit"))


### PR DESCRIPTION
u/aardi wrote:

> The setup needs quite a bit of work. Initially I was surprised about
> "cond: nnreddit-rpc-request: response timed out" each time I tried to
> start gnus, and only noticed later that my browser on a different
> desktop had lots of new tabs open - that should be documented.

I added an alert in the echo area.  Usage documentation is largely ignored, and would rather keep the README as brief as possible.

> Also, there's the "python setup.py" line which probably also should
> use nnreddit-python-command.

Python, when run in the virtualenv, should always be referred to as `python`.  That is the point of virtualenv; it normalizes the system executable to `python`.  I added a comment to clarify.

> The endpoint bind address for the oauth stuff should be configurable.
> My browser runs isolated from the rest of the system, so "127.0.0.1"
> is different for the two of them. Hence I'm stuck at that setup
> process.

Okay.