### PR TITLE
cl-loop scoping misunderstanding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 .PHONY: test-compile
 test-compile: autoloads
 	pylint nnreddit
-	sh -e tools/package-lint.sh
+	sh -e tools/package-lint.sh lisp/nnreddit.el
 	cask install
 	! (cask eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):")
 	cask clean-elc

--- a/lisp/nnreddit.el
+++ b/lisp/nnreddit.el
@@ -534,7 +534,7 @@ Set flag for the ensuing `nnreddit-request-group' to avoid going out to PRAW yet
                   (if (or (not (stringp newsrc-seen-id))
                           (zerop (nnreddit--base10 newsrc-seen-id)))
                       1
-                    (cl-loop for cand = nil
+                    (cl-loop with cand
                              for plst in headers
                              for i = 1 then (1+ i)
                              if (= (nnreddit--base10 (plist-get plst :id))

--- a/tools/package-lint.sh
+++ b/tools/package-lint.sh
@@ -24,13 +24,14 @@ else
     ERROR_ON_WARN=t
 fi
 
+BASENAME=$(basename $1)
 "$EMACS" -Q -batch \
          --eval "$INIT_PACKAGE_EL" \
          -l package-lint.el \
-         --visit lisp/nnreddit.el \
+         --visit $1 \
          --eval "(checkdoc-eval-current-buffer)" \
          --eval "(princ (with-current-buffer checkdoc-diagnostic-buffer (buffer-string)))" \
-         2>&1 | egrep -a "^nnreddit.el:" | egrep -v "Messages should start" && [ -n "${EMACS_LINT_IGNORE+x}" ]
+         2>&1 | egrep -a "^$BASENAME:" | egrep -v "Messages should start" && [ -n "${EMACS_LINT_IGNORE+x}" ]
 
 # Lint ourselves
 # Lint failures are ignored if EMACS_LINT_IGNORE is defined, so that lint
@@ -42,4 +43,4 @@ fi
          --eval "$INIT_PACKAGE_EL" \
          -l package-lint.el \
          -f package-lint-batch-and-exit \
-         lisp/nnreddit.el || [ -n "${EMACS_LINT_IGNORE+x}" ]
+         $1 || [ -n "${EMACS_LINT_IGNORE+x}" ]


### PR DESCRIPTION
`setq` in a `cl-loop` mutates `with` variables, not `for`.