### PR TITLE
Print auth URL in case of webbrowser failure

### DIFF
--- a/nnreddit/authenticated_reddit.py
+++ b/nnreddit/authenticated_reddit.py
@@ -121,7 +121,7 @@ class AuthenticatedReddit(Reddit):
             docs_sub = re.compile(r'reddit terminal viewer', re.IGNORECASE)
             docs.OAUTH_SUCCESS = docs_sub.sub('nnreddit', docs.OAUTH_SUCCESS)
             docs.OAUTH_ACCESS_DENIED = docs_sub.sub('nnreddit', docs.OAUTH_ACCESS_DENIED)
-            print("::user::Please check your browser.", file=sys.stderr)
+            print(f"::user::Please check your browser or visit {url} manually.", file=sys.stderr)
             if cfg.token_file == "/dev/null":
                 cfg.refresh_token = None
             else:


### PR DESCRIPTION
I ran into #94, but while I don't have an answer for why it's failing, I think it's wise to have a fallback link printed, just so there's a way to proceed.